### PR TITLE
header-buttons-fix

### DIFF
--- a/frontend/src/shared/ui/Button.module.scss
+++ b/frontend/src/shared/ui/Button.module.scss
@@ -38,3 +38,17 @@
         background-color: var(--bg-hover-primary);
     }
 }
+
+.headerButton {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+    height: 38px;
+    border-radius: 100%;
+    padding: .8rem;
+    transition: background-color .1s ease-in-out;
+    &:hover {
+        background-color: var(--bg-hover-primary);
+    }
+}

--- a/frontend/src/shared/ui/Popover.tsx
+++ b/frontend/src/shared/ui/Popover.tsx
@@ -40,7 +40,7 @@ Popover.Content = ({
   children,
   className,
   variant,
-  align = "center",
+  align = "end",
   side = "bottom",
 }: PopoverContentProps) => {
   const ref = useRef<HTMLDivElement>(null);

--- a/frontend/src/widgets/header/ui/Header.module.scss
+++ b/frontend/src/widgets/header/ui/Header.module.scss
@@ -1,22 +1,15 @@
 @use "@/shared/styles/abstracts/text-styles" as text-styles;
 
-.headerContainer {
+.header {
     position: sticky;
     top: 0;
-
     background-color: var(--bg-primary);
-    padding: 1.2rem 1.6rem;
-    width: 100%;
-
-    border-bottom: 1px solid var(--border);
-}
-
-.header {
+    padding: 1.2rem 20.1rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    margin: 0 18.5rem;
+    width: 100%;    
+    border-bottom: 1px solid var(--border);
 }
 
 .titleWrapper {
@@ -77,9 +70,7 @@
 
         transition: background-color .1s ease-in-out;
 
-        .sunSvg {
-            stroke: #e9e6e6;
-        }
+
 
         &:hover {
             background-color: var(--bg-hover-primary);
@@ -89,4 +80,8 @@
     .language {
         @include text-styles.text-small-semibold-uppercase;
     }
+}
+
+.sunSvg {
+    stroke: #e9e6e6;
 }

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -1,6 +1,6 @@
 import styles from "./Header.module.scss";
 import { UserMenu } from "./UserMenu/UserMenu";
-
+import { Button } from "@/shared/ui/Button";
 
 import { ReactComponent as LogoSvg } from "@/shared/assets/header/Logo.svg";
 import { ReactComponent as SunSvg } from "@/shared/assets/header/Sun.svg";
@@ -20,8 +20,8 @@ export const Header = () => {
     const { t } = useTranslation();
 
     return (
-        <header className={ styles.headerContainer }>
-            <div className={ styles.header }>
+        <header className={ styles.header }>
+
                 <div className={ styles.titleWrapper }>
                     <LogoSvg className={ styles.logoSvg }/>
                     <h2 className={ styles.title }>FilmHub</h2>
@@ -39,20 +39,19 @@ export const Header = () => {
                     </div>
 
 
-                    <button className={ styles.button } onClick={ toggleTheme }>
-                        { theme === "dark" ? <SunSvg className={ styles.sunSvg }/> : <MoonSvg/> }
-                    </button>
+                    <Button variant="headerButton" onClick={toggleTheme}>
+                        {theme === "dark" ? <SunSvg className={ styles.sunSvg }/> : <MoonSvg />}
+                    </Button>
 
-                    <button
-                        className={ styles.button }
-                        onClick={ () => changeLanguage(language === "en" ? "ru" : "en") }
-                    >
-                        <span className={ styles.language }>{ language === "en" ? "en" : "ru" }</span>
-                    </button>
+                    <Button variant="headerButton" onClick={() => changeLanguage(language === "en" ? "ru" : "en")}>
+                        <span className={styles.language}>{language === "en" ? "en" : "ru"}</span>
+                    </Button>
+
+
 
                     <UserMenu />
                 </nav>
-            </div>
+
         </header>
     );
 };

--- a/frontend/src/widgets/sidebar/ui/Sidebar.module.scss
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.module.scss
@@ -19,8 +19,15 @@
         border-right: 1px solid var(--border);
 
         padding: 2.4rem 1.6rem 8rem 1.6rem;
+
+        .plusIcon {
+            stroke-width: 3px;
+            color: var(--bg-primary);
+        }
     }
 }
+
+
 
 .wrapperInput {
     display: flex;

--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -9,6 +9,8 @@ import { CollapsibleSidebarSection } from "@/widgets/sidebar/ui/CollapsibleSideb
 import { Button } from "@/shared/ui/Button.tsx";
 import { Input } from "@/shared/ui/Input.tsx";
 
+import { Plus } from "lucide-react";
+
 export const Sidebar = () => {
 
     const { t } = useTranslation();
@@ -22,7 +24,7 @@ export const Sidebar = () => {
                         type={ "text" }
                         placeholder={ t("createCategory") }
                     />
-                    <Button variant={ "addCategoryBtn" }>+</Button>
+                    <Button variant={ "addCategoryBtn" }><Plus size={22} className={styles.plusIcon} /></Button>
                 </div>
 
                 <section>


### PR DESCRIPTION
1. Заменил два button в Header на компонент Button с поддержкой прокидывания variant.
2. Убрал класс headerContainer и лишнюю обёртку div, объединил всё в один header с общим классом.
3. Поправил позиционирование Popover, теперь открывается от края аватарки, а не из центра.
4. Добавил svg иконку от lucide в addCategoryBtn.